### PR TITLE
Add option for providing PIL Image directly.

### DIFF
--- a/colorthief.py
+++ b/colorthief.py
@@ -29,14 +29,17 @@ class cached_property(object):
 
 class ColorThief(object):
     """Color thief main class."""
-    def __init__(self, file):
+    def __init__(self, im):
         """Create one color thief for one image.
 
-        :param file: A filename (string) or a file object. The file object
-                     must implement `read()`, `seek()`, and `tell()` methods,
-                     and be opened in binary mode.
+        :param im: A filename (string), a file object, or a PIL Image.
+                     A file object must implement `read()`, `seek()`, and
+                     `tell()` methods, and be opened in binary mode.
         """
-        self.image = Image.open(file)
+        if isinstance(im, Image):
+            self.image = im
+        else:
+            self.image = Image.open(im)
 
     def get_color(self, quality=10):
         """Get the dominant color.


### PR DESCRIPTION
Constructor could accept a PIL image directly - odds are good that someone using this is going to be doing more image operations than just this, and given that, user probably has a PIL image sitting around already.